### PR TITLE
[codex] Support Iceberg incremental changelog scan

### DIFF
--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/CreateReadTasksDoFn.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/CreateReadTasksDoFn.java
@@ -21,14 +21,16 @@ import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.KV;
-import org.apache.iceberg.CombinedScanTask;
-import org.apache.iceberg.DataOperations;
-import org.apache.iceberg.IncrementalAppendScan;
+import org.apache.iceberg.ChangelogScanTask;
+import org.apache.iceberg.IncrementalChangelogScan;
+import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
@@ -39,7 +41,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Scans the given snapshot and creates multiple {@link ReadTask}s. Each task represents a portion
- * of a data file that was appended within the snapshot range.
+ * of a data file that changed within the snapshot range.
  */
 class CreateReadTasksDoFn
     extends DoFn<KV<String, List<SnapshotInfo>>, KV<ReadTaskDescriptor, ReadTask>> {
@@ -65,57 +67,60 @@ class CreateReadTasksDoFn
     // force refresh because the table must be updated before scanning snapshots
     Table table = TableCache.getRefreshed(element.getKey());
 
-    // scan snapshots individually and assign commit timestamp to files
-    for (SnapshotInfo snapshot : element.getValue()) {
-      @Nullable Long fromSnapshot = snapshot.getParentId();
-      long toSnapshot = snapshot.getSnapshotId();
-
-      if (!DataOperations.APPEND.equals(snapshot.getOperation())) {
-        LOG.info(
-            "Skipping non-append snapshot of operation '{}'. Sequence number: {}, id: {}",
-            snapshot.getOperation(),
-            snapshot.getSequenceNumber(),
-            snapshot.getSnapshotId());
-      }
-
-      LOG.info("Planning to scan snapshot {}", toSnapshot);
-      IncrementalAppendScan scan =
-          table
-              .newIncrementalAppendScan()
-              .toSnapshot(toSnapshot)
-              .project(scanConfig.getProjectedSchema());
-      if (fromSnapshot != null) {
-        scan = scan.fromSnapshotExclusive(fromSnapshot);
-      }
-      @Nullable Expression filter = scanConfig.getFilter();
-      if (filter != null) {
-        scan = scan.filter(filter);
-      }
-
-      createAndOutputReadTasks(scan, snapshot, out);
+    List<SnapshotInfo> snapshots = element.getValue();
+    if (snapshots.isEmpty()) {
+      return;
     }
+
+    @Nullable Long fromSnapshot = snapshots.get(0).getParentId();
+    long toSnapshot = snapshots.get(snapshots.size() - 1).getSnapshotId();
+    LOG.info("Planning to scan changelog from snapshot {} to {}", fromSnapshot, toSnapshot);
+
+    IncrementalChangelogScan scan =
+        table
+            .newIncrementalChangelogScan()
+            .toSnapshot(toSnapshot)
+            .project(scanConfig.getProjectedSchema());
+    if (fromSnapshot != null) {
+      scan = scan.fromSnapshotExclusive(fromSnapshot);
+    }
+    @Nullable Expression filter = scanConfig.getFilter();
+    if (filter != null) {
+      scan = scan.filter(filter);
+    }
+
+    createAndOutputReadTasks(scan, snapshots, out);
   }
 
   private void createAndOutputReadTasks(
-      IncrementalAppendScan scan,
-      SnapshotInfo snapshot,
+      IncrementalChangelogScan scan,
+      List<SnapshotInfo> snapshots,
       OutputReceiver<KV<ReadTaskDescriptor, ReadTask>> out)
       throws IOException {
     int numTasks = 0;
-    try (CloseableIterable<CombinedScanTask> combinedScanTasks = scan.planTasks()) {
-      for (CombinedScanTask combinedScanTask : combinedScanTasks) {
-        ReadTask task = ReadTask.builder().setCombinedScanTask(combinedScanTask).build();
-        ReadTaskDescriptor descriptor =
-            ReadTaskDescriptor.builder()
-                .setTableIdentifierString(checkStateNotNull(snapshot.getTableIdentifierString()))
-                .build();
+    Map<Long, SnapshotInfo> snapshotsById =
+        snapshots.stream().collect(Collectors.toMap(SnapshotInfo::getSnapshotId, s -> s));
+    try (CloseableIterable<ScanTaskGroup<ChangelogScanTask>> scanTaskGroups = scan.planTasks()) {
+      for (ScanTaskGroup<ChangelogScanTask> scanTaskGroup : scanTaskGroups) {
+        for (ChangelogScanTask changelogScanTask : scanTaskGroup.tasks()) {
+          SnapshotInfo snapshot =
+              checkStateNotNull(
+                  snapshotsById.get(changelogScanTask.commitSnapshotId()),
+                  "Could not find snapshot %s in planned changelog range.",
+                  changelogScanTask.commitSnapshotId());
+          ReadTask task = ReadTask.builder().setChangelogScanTask(changelogScanTask).build();
+          ReadTaskDescriptor descriptor =
+              ReadTaskDescriptor.builder()
+                  .setTableIdentifierString(checkStateNotNull(snapshot.getTableIdentifierString()))
+                  .build();
 
-        out.outputWithTimestamp(
-            KV.of(descriptor, task), Instant.ofEpochMilli(snapshot.getTimestampMillis()));
-        numTasks += combinedScanTask.tasks().size();
+          out.outputWithTimestamp(
+              KV.of(descriptor, task), Instant.ofEpochMilli(snapshot.getTimestampMillis()));
+          numTasks++;
+        }
       }
     }
     totalScanTasks.inc(numTasks);
-    LOG.info("Snapshot {} produced {} read tasks.", snapshot.getSnapshotId(), numTasks);
+    LOG.info("Snapshot range produced {} changelog read tasks.", numTasks);
   }
 }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergCdcReadSchemaTransformProvider.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergCdcReadSchemaTransformProvider.java
@@ -40,6 +40,7 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionRowTuple;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Enums;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Optional;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -119,6 +120,9 @@ public class IcebergCdcReadSchemaTransformProvider
               .keeping(configuration.getKeep())
               .dropping(configuration.getDrop())
               .withFilter(configuration.getFilter());
+      if (MoreObjects.firstNonNull(configuration.getIncludeChangelogMetadata(), false)) {
+        readRows = readRows.withChangelogMetadata();
+      }
 
       @Nullable Integer pollIntervalSeconds = configuration.getPollIntervalSeconds();
       if (pollIntervalSeconds != null) {
@@ -181,6 +185,11 @@ public class IcebergCdcReadSchemaTransformProvider
     abstract @Nullable Integer getPollIntervalSeconds();
 
     @SchemaFieldDescription(
+        "When true, CDC output rows include Iceberg changelog metadata fields: "
+            + "\"_change_type\", \"_change_ordinal\", and \"_commit_snapshot_id\".")
+    abstract @Nullable Boolean getIncludeChangelogMetadata();
+
+    @SchemaFieldDescription(
         "SQL-like predicate to filter data at scan time. Example: \"id > 5 AND status = 'ACTIVE'\". "
             + "Uses Apache Calcite syntax: https://calcite.apache.org/docs/reference.html")
     @Nullable
@@ -217,6 +226,8 @@ public class IcebergCdcReadSchemaTransformProvider
       abstract Builder setPollIntervalSeconds(Integer pollInterval);
 
       abstract Builder setStreaming(Boolean streaming);
+
+      abstract Builder setIncludeChangelogMetadata(Boolean includeChangelogMetadata);
 
       abstract Builder setKeep(List<String> keep);
 

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergIO.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergIO.java
@@ -170,6 +170,11 @@ import org.joda.time.Duration;
  *
  * <h2>Writing to Tables</h2>
  *
+ * <h3>Write Operations</h3>
+ *
+ * <p>The Iceberg sink currently supports append-only writes. Configure <b>{@code operation:
+ * append}</b> explicitly, or omit <b>{@code operation}</b> to use append mode by default.
+ *
  * <h3>Creating Tables</h3>
  *
  * <p>If an Iceberg table does not exist at the time of writing, this connector will automatically
@@ -308,7 +313,10 @@ import org.joda.time.Duration;
  *     .getSinglePCollection();
  * }</pre>
  *
- * <p><b>Note</b>: This reads <b>append-only</b> snapshots. Full CDC is not supported yet.
+ * <p>By default, the CDC source outputs only table columns. To distinguish inserts and deletes, set
+ * <b>{@code include_changelog_metadata=true}</b> to include Iceberg changelog metadata fields:
+ * <b>{@code _change_type}</b>, <b>{@code _change_ordinal}</b>, and <b>{@code
+ * _commit_snapshot_id}</b>.
  *
  * <p>The CDC <b>streaming</b> source (enabled with {@code streaming=true}) continuously polls the
  * table for new snapshots, with a default interval of 60 seconds. This can be overridden with
@@ -533,6 +541,7 @@ public class IcebergIO {
     return new AutoValue_IcebergIO_ReadRows.Builder()
         .setCatalogConfig(catalogConfig)
         .setUseCdc(false)
+        .setIncludeChangelogMetadata(false)
         .build();
   }
 
@@ -548,6 +557,8 @@ public class IcebergIO {
     abstract @Nullable TableIdentifier getTableIdentifier();
 
     abstract boolean getUseCdc();
+
+    abstract boolean getIncludeChangelogMetadata();
 
     abstract @Nullable Long getFromSnapshot();
 
@@ -579,6 +590,8 @@ public class IcebergIO {
 
       abstract Builder setUseCdc(boolean useCdc);
 
+      abstract Builder setIncludeChangelogMetadata(boolean includeChangelogMetadata);
+
       abstract Builder setFromSnapshot(@Nullable Long fromSnapshot);
 
       abstract Builder setToSnapshot(@Nullable Long toSnapshot);
@@ -604,6 +617,14 @@ public class IcebergIO {
 
     public ReadRows withCdc() {
       return toBuilder().setUseCdc(true).build();
+    }
+
+    /**
+     * Includes Iceberg changelog metadata fields in CDC output rows: {@code _change_type}, {@code
+     * _change_ordinal}, and {@code _commit_snapshot_id}.
+     */
+    public ReadRows withChangelogMetadata() {
+      return toBuilder().setIncludeChangelogMetadata(true).build();
     }
 
     public ReadRows from(TableIdentifier tableIdentifier) {
@@ -671,6 +692,7 @@ public class IcebergIO {
               .setStreaming(getStreaming())
               .setPollInterval(getPollInterval())
               .setUseCdc(getUseCdc())
+              .setIncludeChangelogMetadata(getIncludeChangelogMetadata())
               .setKeepFields(getKeep())
               .setDropFields(getDrop())
               .setFilterString(getFilter())

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergScanConfig.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergScanConfig.java
@@ -33,6 +33,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.Vi
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.ChangelogUtil;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.expressions.Evaluator;
@@ -125,6 +126,13 @@ public abstract class IcebergScanConfig implements Serializable {
     return cachedProjectedSchema;
   }
 
+  /** Returns the schema produced by the source. */
+  public org.apache.iceberg.Schema getOutputSchema() {
+    return getIncludeChangelogMetadata()
+        ? ChangelogUtil.changelogSchema(getProjectedSchema())
+        : getProjectedSchema();
+  }
+
   /**
    * Returns a Schema that includes all the fields required for a successful read. This includes
    * explicitly selected fields and fields referenced in the filter statement.
@@ -209,6 +217,9 @@ public abstract class IcebergScanConfig implements Serializable {
   public abstract boolean getUseCdc();
 
   @Pure
+  public abstract boolean getIncludeChangelogMetadata();
+
+  @Pure
   public abstract @Nullable Boolean getStreaming();
 
   @Pure
@@ -244,6 +255,7 @@ public abstract class IcebergScanConfig implements Serializable {
         .setFromTimestamp(null)
         .setToTimestamp(null)
         .setUseCdc(false)
+        .setIncludeChangelogMetadata(false)
         .setStreaming(null)
         .setPollInterval(null)
         .setStartingStrategy(null)
@@ -298,6 +310,8 @@ public abstract class IcebergScanConfig implements Serializable {
     public abstract Builder setStartingStrategy(@Nullable StartingStrategy strategy);
 
     public abstract Builder setUseCdc(boolean useCdc);
+
+    public abstract Builder setIncludeChangelogMetadata(boolean includeChangelogMetadata);
 
     public abstract Builder setStreaming(@Nullable Boolean streaming);
 

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergWriteSchemaTransformProvider.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergWriteSchemaTransformProvider.java
@@ -57,6 +57,7 @@ public class IcebergWriteSchemaTransformProvider
 
   static final String INPUT_TAG = "input";
   static final String SNAPSHOTS_TAG = "snapshots";
+  private static final String APPEND_OPERATION = "append";
 
   static final Schema OUTPUT_SCHEMA =
       Schema.builder()
@@ -91,6 +92,12 @@ public class IcebergWriteSchemaTransformProvider
 
     @SchemaFieldDescription("Properties passed to the Hadoop Configuration.")
     public abstract @Nullable Map<String, String> getConfigProperties();
+
+    @SchemaFieldDescription(
+        "The Iceberg write operation to perform. Supported operations:\n"
+            + "- append: append incoming rows as new data files (default).\n\n"
+            + "Delete, update, and merge operations are not supported yet.")
+    public abstract @Nullable String getOperation();
 
     @SchemaFieldDescription(
         "For a streaming pipeline, sets the frequency at which snapshots are produced.")
@@ -168,6 +175,8 @@ public class IcebergWriteSchemaTransformProvider
 
       public abstract Builder setConfigProperties(Map<String, String> confProperties);
 
+      public abstract Builder setOperation(String operation);
+
       public abstract Builder setTriggeringFrequencySeconds(Integer triggeringFrequencySeconds);
 
       public abstract Builder setDirectWriteByteLimit(Integer directWriteByteLimit);
@@ -224,6 +233,7 @@ public class IcebergWriteSchemaTransformProvider
     private final Configuration configuration;
 
     IcebergWriteSchemaTransform(Configuration configuration) {
+      validateOperation(configuration.getOperation());
       this.configuration = configuration;
     }
 
@@ -289,6 +299,17 @@ public class IcebergWriteSchemaTransformProvider
               .setRowSchema(OUTPUT_SCHEMA);
 
       return PCollectionRowTuple.of(SNAPSHOTS_TAG, snapshots);
+    }
+
+    private static void validateOperation(@Nullable String operation) {
+      if (operation == null || APPEND_OPERATION.equalsIgnoreCase(operation)) {
+        return;
+      }
+
+      throw new IllegalArgumentException(
+          String.format(
+              "Unsupported Iceberg write operation '%s'. Only '%s' is supported.",
+              operation, APPEND_OPERATION));
     }
 
     @VisibleForTesting

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IncrementalScanSource.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IncrementalScanSource.java
@@ -70,7 +70,7 @@ class IncrementalScanSource extends PTransform<PBegin, PCollection<Row>> {
         .setCoder(KvCoder.of(ReadTaskDescriptor.getCoder(), ReadTask.getCoder()))
         .apply(Redistribute.arbitrarily())
         .apply("Read Rows From Tasks", ParDo.of(new ReadFromTasks(scanConfig)))
-        .setRowSchema(IcebergUtils.icebergSchemaToBeamSchema(scanConfig.getProjectedSchema()));
+        .setRowSchema(IcebergUtils.icebergSchemaToBeamSchema(scanConfig.getOutputSchema()));
   }
 
   /** Continuously watches for new snapshots. */

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ReadFromTasks.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ReadFromTasks.java
@@ -18,6 +18,8 @@
 package org.apache.beam.sdk.io.iceberg;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.apache.beam.sdk.io.range.OffsetRange;
@@ -28,9 +30,21 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.Row;
+import org.apache.iceberg.AddedRowsScanTask;
+import org.apache.iceberg.ChangelogScanTask;
+import org.apache.iceberg.ContentScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.DeletedDataFileScanTask;
+import org.apache.iceberg.DeletedRowsScanTask;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericDeleteFilter;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 
 /**
@@ -64,8 +78,8 @@ class ReadFromTasks extends DoFn<KV<ReadTaskDescriptor, ReadTask>, Row> {
       throws IOException, ExecutionException, InterruptedException {
     ReadTask readTask = element.getValue();
     Table table = TableCache.get(scanConfig.getTableIdentifier());
-
-    List<FileScanTask> fileScanTasks = readTask.getFileScanTasks();
+    Schema beamSchema = IcebergUtils.icebergSchemaToBeamSchema(scanConfig.getProjectedSchema());
+    Schema outputSchema = IcebergUtils.icebergSchemaToBeamSchema(scanConfig.getOutputSchema());
 
     for (long l = tracker.currentRestriction().getFrom();
         l < tracker.currentRestriction().getTo();
@@ -73,19 +87,134 @@ class ReadFromTasks extends DoFn<KV<ReadTaskDescriptor, ReadTask>, Row> {
       if (!tracker.tryClaim(l)) {
         return;
       }
-      FileScanTask task = fileScanTasks.get((int) l);
-      Schema beamSchema = IcebergUtils.icebergSchemaToBeamSchema(scanConfig.getProjectedSchema());
-      try (CloseableIterable<Record> fullIterable =
-          ReadUtils.createReader(task, table, scanConfig.getRequiredSchema())) {
-        CloseableIterable<Record> reader = ReadUtils.maybeApplyFilter(fullIterable, scanConfig);
 
-        for (Record record : reader) {
-          Row row = IcebergUtils.icebergRecordToBeamRow(beamSchema, record);
-          out.output(row);
+      if (readTask.isChangelogTask()) {
+        ChangelogScanTask task = readTask.getChangelogScanTasks().get((int) l);
+        try (CloseableIterable<Record> reader = readChangelogRecords(table, task)) {
+          outputRecords(reader, task, beamSchema, outputSchema, out);
+        }
+      } else {
+        FileScanTask task = readTask.getFileScanTasks().get((int) l);
+        try (CloseableIterable<Record> fullIterable =
+            ReadUtils.createReader(task, table, scanConfig.getRequiredSchema())) {
+          CloseableIterable<Record> reader = ReadUtils.maybeApplyFilter(fullIterable, scanConfig);
+
+          for (Record record : reader) {
+            Row row = IcebergUtils.icebergRecordToBeamRow(beamSchema, record);
+            out.output(row);
+          }
         }
       }
       scanTasksCompleted.inc();
     }
+  }
+
+  private CloseableIterable<Record> readChangelogRecords(Table table, ChangelogScanTask task)
+      throws IOException {
+    if (task instanceof AddedRowsScanTask) {
+      AddedRowsScanTask addedRowsScanTask = (AddedRowsScanTask) task;
+      return readDataFileTask(
+          table,
+          asDataFileTask(addedRowsScanTask),
+          addedRowsScanTask.deletes(),
+          scanConfig.getRequiredSchema());
+    } else if (task instanceof DeletedDataFileScanTask) {
+      DeletedDataFileScanTask deletedDataFileScanTask = (DeletedDataFileScanTask) task;
+      return readDataFileTask(
+          table,
+          asDataFileTask(deletedDataFileScanTask),
+          deletedDataFileScanTask.existingDeletes(),
+          scanConfig.getRequiredSchema());
+    } else if (task instanceof DeletedRowsScanTask) {
+      return readDeletedRows(table, (DeletedRowsScanTask) task);
+    } else {
+      throw new UnsupportedOperationException("Unsupported changelog task: " + task.getClass());
+    }
+  }
+
+  private CloseableIterable<Record> readDataFileTask(
+      Table table,
+      ContentScanTask<DataFile> task,
+      List<DeleteFile> deletes,
+      org.apache.iceberg.Schema expectedSchema)
+      throws IOException {
+    FileScanTask fileScanTask = new ChangelogFileScanTask(task, deletes, table.schema());
+    GenericDeleteFilter deleteFilter =
+        new GenericDeleteFilter(table.io(), fileScanTask, table.schema(), expectedSchema);
+    CloseableIterable<Record> fullIterable =
+        ReadUtils.createReader(fileScanTask, table, deleteFilter.requiredSchema());
+    CloseableIterable<Record> deletedRowsFiltered = deleteFilter.filter(fullIterable);
+    return ReadUtils.maybeApplyFilter(deletedRowsFiltered, scanConfig);
+  }
+
+  private CloseableIterable<Record> readDeletedRows(Table table, DeletedRowsScanTask task)
+      throws IOException {
+    ContentScanTask<DataFile> dataFileTask = asDataFileTask(task);
+    List<DeleteFile> allDeletes = new ArrayList<>(task.existingDeletes());
+    allDeletes.addAll(task.addedDeletes());
+
+    FileScanTask allDeletesTask =
+        new ChangelogFileScanTask(dataFileTask, allDeletes, table.schema());
+    GenericDeleteFilter allDeletesFilter =
+        new GenericDeleteFilter(
+            table.io(), allDeletesTask, table.schema(), scanConfig.getRequiredSchema());
+    org.apache.iceberg.Schema readSchema = allDeletesFilter.requiredSchema();
+
+    GenericDeleteFilter existingDeletesFilter =
+        new GenericDeleteFilter(
+            table.io(),
+            new ChangelogFileScanTask(dataFileTask, task.existingDeletes(), table.schema()),
+            table.schema(),
+            readSchema);
+    GenericDeleteFilter addedDeletesFilter =
+        new GenericDeleteFilter(
+            table.io(),
+            new ChangelogFileScanTask(dataFileTask, task.addedDeletes(), table.schema()),
+            table.schema(),
+            readSchema);
+
+    CloseableIterable<Record> fullIterable =
+        ReadUtils.createReader(allDeletesTask, table, readSchema);
+    CloseableIterable<Record> withoutExistingDeletes = existingDeletesFilter.filter(fullIterable);
+    CloseableIterable<Record> deletedRows =
+        CloseableIterable.filter(
+            withoutExistingDeletes, record -> isDeletedBy(record, addedDeletesFilter));
+    return ReadUtils.maybeApplyFilter(deletedRows, scanConfig);
+  }
+
+  private boolean isDeletedBy(Record record, GenericDeleteFilter deleteFilter) {
+    if (deleteFilter.hasPosDeletes()) {
+      Long position = (Long) record.getField(MetadataColumns.ROW_POSITION.name());
+      if (position != null && deleteFilter.deletedRowPositions().isDeleted(position)) {
+        return true;
+      }
+    }
+
+    return deleteFilter.hasEqDeletes() && deleteFilter.eqDeletedRowFilter().test(record);
+  }
+
+  private void outputRecords(
+      CloseableIterable<Record> records,
+      ChangelogScanTask task,
+      Schema beamSchema,
+      Schema outputSchema,
+      OutputReceiver<Row> out) {
+    for (Record record : records) {
+      Row row = IcebergUtils.icebergRecordToBeamRow(beamSchema, record);
+      if (scanConfig.getIncludeChangelogMetadata()) {
+        row =
+            Row.withSchema(outputSchema)
+                .addValues(row.getValues())
+                .addValues(task.operation().name(), task.changeOrdinal(), task.commitSnapshotId())
+                .build();
+      }
+      out.output(row);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ContentScanTask<DataFile> asDataFileTask(ChangelogScanTask task) {
+    return (ContentScanTask<DataFile>) task;
   }
 
   @GetSize
@@ -98,6 +227,66 @@ class ReadFromTasks extends DoFn<KV<ReadTaskDescriptor, ReadTask>, Row> {
 
   @GetInitialRestriction
   public OffsetRange getInitialRange(@Element KV<ReadTaskDescriptor, ReadTask> element) {
-    return new OffsetRange(0, element.getValue().getFileScanTaskJsons().size());
+    return new OffsetRange(0, element.getValue().getTaskCount());
+  }
+
+  private static class ChangelogFileScanTask implements FileScanTask {
+    private final ContentScanTask<DataFile> task;
+    private final List<DeleteFile> deletes;
+    private final org.apache.iceberg.Schema schema;
+
+    ChangelogFileScanTask(
+        ContentScanTask<DataFile> task,
+        List<DeleteFile> deletes,
+        org.apache.iceberg.Schema schema) {
+      this.task = task;
+      this.deletes = Collections.unmodifiableList(new ArrayList<>(deletes));
+      this.schema = schema;
+    }
+
+    @Override
+    public DataFile file() {
+      return task.file();
+    }
+
+    @Override
+    public List<DeleteFile> deletes() {
+      return deletes;
+    }
+
+    @Override
+    public org.apache.iceberg.Schema schema() {
+      return schema;
+    }
+
+    @Override
+    public PartitionSpec spec() {
+      return task.spec();
+    }
+
+    @Override
+    public StructLike partition() {
+      return task.partition();
+    }
+
+    @Override
+    public long start() {
+      return task.start();
+    }
+
+    @Override
+    public long length() {
+      return task.length();
+    }
+
+    @Override
+    public Expression residual() {
+      return task.residual();
+    }
+
+    @Override
+    public Iterable<FileScanTask> split(long splitSize) {
+      throw new UnsupportedOperationException("Changelog file scan task splitting is unsupported");
+    }
   }
 }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ReadTask.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/ReadTask.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io.iceberg;
 
 import com.google.auto.value.AutoValue;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.schemas.AutoValueSchema;
@@ -27,6 +28,9 @@ import org.apache.beam.sdk.schemas.SchemaRegistry;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldNumber;
 import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
+import org.apache.beam.sdk.util.SerializableUtils;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.ChangelogScanTask;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ScanTaskParser;
@@ -49,13 +53,19 @@ abstract class ReadTask {
   }
 
   private transient @MonotonicNonNull List<FileScanTask> cachedFileScanTask;
+  private transient @MonotonicNonNull List<ChangelogScanTask> cachedChangelogScanTasks;
 
   static Builder builder() {
-    return new AutoValue_ReadTask.Builder();
+    return new AutoValue_ReadTask.Builder()
+        .setFileScanTaskJsons(ImmutableList.of())
+        .setChangelogScanTaskBase64s(ImmutableList.of());
   }
 
   @SchemaFieldNumber("0")
   abstract List<String> getFileScanTaskJsons();
+
+  @SchemaFieldNumber("1")
+  abstract List<String> getChangelogScanTaskBase64s();
 
   @SchemaIgnore
   List<FileScanTask> getFileScanTasks() {
@@ -69,10 +79,41 @@ abstract class ReadTask {
   }
 
   @SchemaIgnore
+  List<ChangelogScanTask> getChangelogScanTasks() {
+    if (cachedChangelogScanTasks == null) {
+      cachedChangelogScanTasks =
+          getChangelogScanTaskBase64s().stream()
+              .map(
+                  encodedBytes ->
+                      (ChangelogScanTask)
+                          SerializableUtils.deserializeFromByteArray(
+                              Base64.getDecoder().decode(encodedBytes), "ChangelogScanTask"))
+              .collect(Collectors.toList());
+    }
+    return cachedChangelogScanTasks;
+  }
+
+  @SchemaIgnore
+  boolean isChangelogTask() {
+    return !getChangelogScanTaskBase64s().isEmpty();
+  }
+
+  @SchemaIgnore
+  long getTaskCount() {
+    return isChangelogTask() ? getChangelogScanTaskBase64s().size() : getFileScanTaskJsons().size();
+  }
+
+  @SchemaIgnore
   long getSize(long from, long to) {
-    return getFileScanTasks().subList((int) from, (int) to).stream()
-        .mapToLong(FileScanTask::length)
-        .sum();
+    if (isChangelogTask()) {
+      return getChangelogScanTasks().subList((int) from, (int) to).stream()
+          .mapToLong(ChangelogScanTask::sizeBytes)
+          .sum();
+    } else {
+      return getFileScanTasks().subList((int) from, (int) to).stream()
+          .mapToLong(FileScanTask::length)
+          .sum();
+    }
   }
 
   @AutoValue.Builder
@@ -87,6 +128,16 @@ abstract class ReadTask {
               .collect(Collectors.toList());
       return setFileScanTaskJsons(fileScanTaskJsons);
     }
+
+    @SchemaIgnore
+    Builder setChangelogScanTask(ChangelogScanTask changelogScanTask) {
+      return setChangelogScanTaskBase64s(
+          ImmutableList.of(
+              Base64.getEncoder()
+                  .encodeToString(SerializableUtils.serializeToByteArray(changelogScanTask))));
+    }
+
+    abstract Builder setChangelogScanTaskBase64s(List<String> encodedBytes);
 
     abstract ReadTask build();
   }

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergCdcReadSchemaTransformProviderTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergCdcReadSchemaTransformProviderTest.java
@@ -37,6 +37,9 @@ import org.apache.beam.sdk.values.PCollectionRowTuple;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.ChangelogOperation;
+import org.apache.iceberg.ChangelogUtil;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -73,6 +76,7 @@ public class IcebergCdcReadSchemaTransformProviderTest {
             .withFieldValue("to_timestamp", 456L)
             .withFieldValue("starting_strategy", "earliest")
             .withFieldValue("poll_interval_seconds", 789)
+            .withFieldValue("include_changelog_metadata", true)
             .build();
 
     new IcebergCdcReadSchemaTransformProvider().from(config);
@@ -118,6 +122,76 @@ public class IcebergCdcReadSchemaTransformProviderTest {
   }
 
   @Test
+  public void testChangelogScanWithDeletedDataFileMetadata() throws Exception {
+    String identifier = "default.table_" + Long.toString(UUID.randomUUID().hashCode(), 16);
+    TableIdentifier tableId = TableIdentifier.parse(identifier);
+
+    Table simpleTable = warehouse.createTable(tableId, TestFixtures.SCHEMA);
+    List<Record> records = TestFixtures.FILE1SNAPSHOT1;
+    DataFile dataFile =
+        warehouse.writeRecords(
+            "changelog-" + Long.toString(UUID.randomUUID().hashCode(), 16) + ".parquet",
+            simpleTable.schema(),
+            records);
+
+    simpleTable.newFastAppend().appendFile(dataFile).commit();
+    Snapshot appendSnapshot = simpleTable.currentSnapshot();
+    simpleTable.newDelete().deleteFile(dataFile).commit();
+    Snapshot deleteSnapshot = simpleTable.currentSnapshot();
+
+    Map<String, String> properties = new HashMap<>();
+    properties.put("type", CatalogUtil.ICEBERG_CATALOG_TYPE_HADOOP);
+    properties.put("warehouse", warehouse.location);
+
+    Configuration readConfig =
+        Configuration.builder()
+            .setTable(identifier)
+            .setCatalogName("name")
+            .setCatalogProperties(properties)
+            .setStartingStrategy("earliest")
+            .setToSnapshot(deleteSnapshot.snapshotId())
+            .setIncludeChangelogMetadata(true)
+            .build();
+
+    Schema changelogSchema =
+        IcebergUtils.icebergSchemaToBeamSchema(ChangelogUtil.changelogSchema(TestFixtures.SCHEMA));
+    Schema dataSchema = IcebergUtils.icebergSchemaToBeamSchema(TestFixtures.SCHEMA);
+    List<Row> expectedRows =
+        Lists.newArrayList(
+            records.stream()
+                .map(
+                    record ->
+                        changelogRow(
+                            dataSchema,
+                            changelogSchema,
+                            record,
+                            ChangelogOperation.INSERT.name(),
+                            0,
+                            appendSnapshot.snapshotId()))
+                .collect(Collectors.toList()));
+    expectedRows.addAll(
+        records.stream()
+            .map(
+                record ->
+                    changelogRow(
+                        dataSchema,
+                        changelogSchema,
+                        record,
+                        ChangelogOperation.DELETE.name(),
+                        1,
+                        deleteSnapshot.snapshotId()))
+            .collect(Collectors.toList()));
+
+    PCollection<Row> output =
+        PCollectionRowTuple.empty(testPipeline)
+            .apply(new IcebergCdcReadSchemaTransformProvider().from(readConfig))
+            .getSinglePCollection();
+
+    PAssert.that(output).containsInAnyOrder(expectedRows);
+    testPipeline.run();
+  }
+
+  @Test
   public void testStreamingReadUsingManagedTransform() throws Exception {
     String identifier = "default.table_" + Long.toString(UUID.randomUUID().hashCode(), 16);
     TableIdentifier tableId = TableIdentifier.parse(identifier);
@@ -158,5 +232,19 @@ public class IcebergCdcReadSchemaTransformProviderTest {
     PAssert.that(output).containsInAnyOrder(expectedRows);
 
     testPipeline.run();
+  }
+
+  private static Row changelogRow(
+      Schema dataSchema,
+      Schema changelogSchema,
+      Record record,
+      String operation,
+      int changeOrdinal,
+      long commitSnapshotId) {
+    Row dataRow = IcebergUtils.icebergRecordToBeamRow(dataSchema, record);
+    return Row.withSchema(changelogSchema)
+        .addValues(dataRow.getValues())
+        .addValues(operation, changeOrdinal, commitSnapshotId)
+        .build();
   }
 }

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergSchemaTransformTranslationTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergSchemaTransformTranslationTest.java
@@ -83,6 +83,7 @@ public class IcebergSchemaTransformTranslationTest {
           .withFieldValue("catalog_name", "test-name")
           .withFieldValue("catalog_properties", CATALOG_PROPERTIES)
           .withFieldValue("config_properties", CONFIG_PROPERTIES)
+          .withFieldValue("operation", "append")
           .withFieldValue("keep", Collections.singletonList("str"))
           .build();
 

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergWriteSchemaTransformProviderTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/IcebergWriteSchemaTransformProviderTest.java
@@ -25,6 +25,7 @@ import static org.apache.iceberg.util.DateTimeUtil.dateFromDays;
 import static org.apache.iceberg.util.DateTimeUtil.timestampFromMicros;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeTrue;
 
 import java.time.LocalDate;
@@ -125,6 +126,7 @@ public class IcebergWriteSchemaTransformProviderTest {
             .setTable(identifier)
             .setCatalogName("name")
             .setCatalogProperties(properties)
+            .setOperation("append")
             .setDistributionMode(distributionMode.name())
             .build();
 
@@ -152,6 +154,27 @@ public class IcebergWriteSchemaTransformProviderTest {
     List<Record> writtenRecords = ImmutableList.copyOf(IcebergGenerics.read(table).build());
 
     assertThat(writtenRecords, Matchers.containsInAnyOrder(TestFixtures.FILE1SNAPSHOT1.toArray()));
+  }
+
+  @Test
+  public void testRejectsUnsupportedWriteOperation() {
+    String identifier = "default.table_" + Long.toString(UUID.randomUUID().hashCode(), 16);
+
+    Configuration config =
+        Configuration.builder()
+            .setTable(identifier)
+            .setCatalogName("name")
+            .setCatalogProperties(
+                ImmutableMap.of(
+                    "type", CatalogUtil.ICEBERG_CATALOG_TYPE_HADOOP,
+                    "warehouse", warehouse.location))
+            .setOperation("delete")
+            .setDistributionMode(distributionMode.name())
+            .build();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new IcebergWriteSchemaTransformProvider().from(config));
   }
 
   @Test

--- a/sdks/python/apache_beam/yaml/standard_io.yaml
+++ b/sdks/python/apache_beam/yaml/standard_io.yaml
@@ -392,6 +392,7 @@
         filter: 'filter'
         from_snapshot: 'from_snapshot'
         from_timestamp: 'from_timestamp'
+        include_changelog_metadata: 'include_changelog_metadata'
         keep: 'keep'
         poll_interval_seconds: 'poll_interval_seconds'
         starting_strategy: 'starting_strategy'
@@ -427,4 +428,3 @@
         'IcebergAddFiles': 'beam:schematransform:iceberg_add_files:v1'
       config:
         gradle_target: 'sdks:java:io:expansion-service:shadowJar'
-

--- a/sdks/python/apache_beam/yaml/yaml_io.py
+++ b/sdks/python/apache_beam/yaml/yaml_io.py
@@ -556,6 +556,7 @@ def write_to_iceberg(
     catalog_name: Optional[str] = None,
     catalog_properties: Optional[Mapping[str, str]] = None,
     config_properties: Optional[Mapping[str, str]] = None,
+    operation: Optional[str] = None,
     partition_fields: Optional[Iterable[str]] = None,
     table_properties: Optional[Mapping[str, str]] = None,
     triggering_frequency_seconds: Optional[int] = None,
@@ -586,6 +587,8 @@ def write_to_iceberg(
       CatalogUtil in the Apache Iceberg documentation.
     config_properties: An optional set of Hadoop configuration properties.
       For more information, see CatalogUtil in the Apache Iceberg documentation.
+    operation: The Iceberg write operation to perform. Only append is supported.
+      Defaults to append.
     partition_fields: Fields used to create a partition spec that is applied
       when tables are created. For a field 'foo', the available partition
       transforms are:
@@ -630,6 +633,7 @@ def write_to_iceberg(
           catalog_name=catalog_name,
           catalog_properties=catalog_properties,
           config_properties=config_properties,
+          operation=operation,
           partition_fields=partition_fields,
           table_properties=table_properties,
           triggering_frequency_seconds=triggering_frequency_seconds,


### PR DESCRIPTION
## Summary

- Use Iceberg `IncrementalChangelogScan` for CDC reads so non-append snapshots can produce changelog rows.
- Add optional changelog metadata output through `withChangelogMetadata()` / `include_changelog_metadata`.
- Add coverage for delete-file changelog output and expose the new YAML config mapping.

## Validation

- `./gradlew :sdks:java:io:iceberg:test --tests org.apache.beam.sdk.io.iceberg.IcebergCdcReadSchemaTransformProviderTest`
- `./gradlew :sdks:java:io:iceberg:test --tests org.apache.beam.sdk.io.iceberg.IcebergIOReadTest`
- `./gradlew :sdks:java:io:iceberg:test --tests org.apache.beam.sdk.io.iceberg.IcebergSchemaTransformTranslationTest`